### PR TITLE
Migrate to prop-types library

### DIFF
--- a/MarkdownView.js
+++ b/MarkdownView.js
@@ -1,8 +1,9 @@
 /* @flow */
 
+import PropTypes from 'prop-types';
+
 import React, {
   Component,
-  PropTypes,
 } from 'react'
 
 import {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-native-tabular-grid": "github:Benjamin-Dobell/react-native-tabular-grid",
     "simple-markdown": "^0.2.1"
   },


### PR DESCRIPTION
`React.PropTypes` [is deprecated as of React v15.5](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). This migrates to the `prop-types` library, which should have no functional consequences.

See also https://github.com/Benjamin-Dobell/react-native-tabular-grid/pull/1.