### PR TITLE
Headings: Allow # headings to be ended with a single newline

### DIFF
--- a/MarkdownView.js
+++ b/MarkdownView.js
@@ -45,7 +45,7 @@ function mergeRules(baseRules, rules) {
   return mergedRules
 }
 
-const IMAGE_LINK = "(?:\\[[^\\]]*\\]|[^\\]]|\\](?=[^\\[]*\\]))*"
+const IMAGE_LINK = "(?:\\[[^\\]]*\\]|[^\\[\\]]|\\](?=[^\\[]*\\]))*";
 const IMAGE_HREF_AND_TITLE = "\\s*<?((?:[^\\s\\\\]|\\\\.)*?)>?(?:\\s+['\"]([\\s\\S]*?)['\"])?"
 const IMAGE_SIZE = "(?:\\s+=([0-9]+)x([0-9]+))?\\)\\s*"
 
@@ -58,6 +58,9 @@ const DefaultRules : Rules = Object.freeze(mergeRules(
     ...Object.entries(DefaultRenders).map(([nodeKey, render]) => ({[nodeKey]: {render: render}}))
   ),
   {
+    heading: {
+      match: SimpleMarkdown.blockRegex(/^ *(#{1,6}) *([^\n]+?) *#* *(?:\n *)*\n/),
+    },
     image: {
       match: inlineRegex(new RegExp("^!\\[(" + IMAGE_LINK + ")\\]\\(" + IMAGE_HREF_AND_TITLE + IMAGE_SIZE)),
       parse: (capture, parse, state): ImageNode => ({

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "prop-types": "^15.5.10",
     "react-native-tabular-grid": "github:Benjamin-Dobell/react-native-tabular-grid",
-    "simple-markdown": "^0.2.1"
+    "simple-markdown": "0.3.x"
   },
   "devDependencies": {
     "flow-bin": "^0.36.0"


### PR DESCRIPTION
Fixes #2

Also see: https://github.com/Khan/simple-markdown/issues/30

Test plan:

I made a react-native project and put this in it, and tried
the following markdown, and got 3 headers instead of one:

    # header 1
    ## header 2
    # header x

    paragraph