### PR TITLE
Fix broken list item bullet type option

### DIFF
--- a/renders.js
+++ b/renders.js
@@ -149,7 +149,7 @@ export default Object.freeze({
               <Text style={styles.listItemNumber}>{`${i + 1}.`}</Text>
               :
               <Text style={styles.listItemBullet}>
-                {styles.listItemBullet && styles.listItemBullet.content ? styles.listItemBullet.content : '\u2022'}
+                {styles.listItemBulletType && styles.listItemBulletType.content ? styles.listItemBulletType.content : '\u2022'}
               </Text>
           }
           <Text style={node.ordered ? styles.listItemOrderedContent : styles.listItemUnorderedContent}>


### PR DESCRIPTION
listItemBullet.content throws a warning for failed prop type on the
styling and does not change the bullet type.
Changed to listItemBulletType.content to only be used for the
overriding of the Bullet Type, now overrides the bullet type.