### PR TITLE
Update rule PropTypes

### DIFF
--- a/MarkdownView.js
+++ b/MarkdownView.js
@@ -148,7 +148,7 @@ MarkdownView.propTypes = {
    *   nptable, lheading, fence, def, escape, autolink, mailto, url, reflink, refimage,
    *
    */
-  rules: PropTypes.objectOf(PropTypes.objectOf(PropTypes.func)),
+  rules: PropTypes.objectOf(PropTypes.objectOf(PropTypes.oneOfType([PropTypes.func, PropTypes.number]))),
 
   /**
    * An object providing styles to be passed to a corresponding rule render method. Keys are


### PR DESCRIPTION
SimpleMarkdown throws error when order property not present on new rule.
Update the rule PropTypes to allow a number (aimed at the order property however may be better to use PropTypes.shape and specify properties individually).