### PR TITLE
Update style PropType to allow Stylesheet IDs

### DIFF
--- a/MarkdownView.js
+++ b/MarkdownView.js
@@ -156,7 +156,7 @@ MarkdownView.propTypes = {
    * default style exists, they will me merged, with style properties defined here taking
    * precedence.
    */
-  styles: PropTypes.objectOf(PropTypes.object),
+  styles: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.object, PropTypes.number])),
 
   /**
    * Callback function for when a link is pressed. The callback receives the URL of the link as a


### PR DESCRIPTION
When using StyleSheets, styles are referenced using number IDs eg.
```javascript
<MarkdownView styles={styles.myMarkdownStyle} ...>

const styles = StyleSheet.create({
    myMarkdownStyle: {...}
})
```
