### PR TITLE
Support for only specifying image height or width

### DIFF
--- a/MarkdownView.js
+++ b/MarkdownView.js
@@ -47,7 +47,7 @@ function mergeRules(baseRules, rules) {
 
 const IMAGE_LINK = "(?:\\[[^\\]]*\\]|[^\\[\\]]|\\](?=[^\\[]*\\]))*";
 const IMAGE_HREF_AND_TITLE = "\\s*<?((?:[^\\s\\\\]|\\\\.)*?)>?(?:\\s+['\"]([\\s\\S]*?)['\"])?"
-const IMAGE_SIZE = "(?:\\s+=([0-9]+)x([0-9]+))?\\)\\s*"
+const IMAGE_SIZE = "(?:\\s+=([0-9]+)?x([0-9]+)?)?\\)\\s*"
 
 const inlineRegex = (regex) => ((source, state) => state.inline ? regex.exec(source) : null)
 const unescapeUrl = (url) => url.replace(/\\([^0-9A-Za-z\s])/g, '$1')

--- a/renders.js
+++ b/renders.js
@@ -30,7 +30,7 @@ import type {
 function renderImage(node: ImageNode, output: OutputFunction, state: RenderState, styles: RenderStyles) {
   const {imageWrapper: wrapperStyle, image: imageStyle} = styles
   return (
-    <View key={state.key} style={node.width && node.height ? [wrapperStyle, paddedSize(node, wrapperStyle)] : wrapperStyle}>
+    <View key={state.key} style={node.width || node.height ? [wrapperStyle, paddedSize(node, wrapperStyle)] : wrapperStyle}>
       <Image source={{uri: node.target}} style={imageStyle}/>
     </View>
   )


### PR DESCRIPTION
This PR adds support for an optional `height` and `width` for the image. Currently both of these are required by the library, but many markdown implementations support only providing one of them.

So you can do `![](./pic/pic1s.png =250x)`.


~~Besides I'm exporting some regular expressions parts and helpers. These are very useful if a user wants to customize the image parser.~~