### PR TITLE
Fix listItemNumber type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare module "react-native-markdown-view" {
         link?: TextStyle;
         list?: ViewStyle;
         listItem?: ViewStyle;
-        listItemNumber?: ViewStyle;
+        listItemNumber?: TextStyle;
         listItemBullet?: TextStyle;
         listItemOrderedContent?: TextStyle;
         listItemUnorderedContent?: TextStyle;


### PR DESCRIPTION
The `listItemNumber` style applies to a `<Text>` component, but it was
defined as a `ViewStyle`. This produced TypeScript errors when passing
the property as part of a `styles` prop.

This commit changes the `listItemNumber` type to a `TextStyle`.

